### PR TITLE
Creating filtering draft_consensus functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Output files may be aggregated including information for all samples or provided
 | Typing results | ./wf-flu-results.csv | Typing results in CSV format for onward processing. | aggregated |
 | Read alignments | ./{{ alias }}/alignments/align.bam | Read allignments per sample in BAM format. | per-sample |
 | Draft consensus FASTA | ./{{ alias }}/consensus/draft.consensus.fasta | Draft consensus sequence. | per-sample |
+| Filtered consensus FASTA | ./{{ alias }}/consensus/filtered_cons.fasta | Filtered consensus sequence above tresh coverage lvl. | per-sample |
 | Read depth | ./{{ alias }}/coverage/depth.txt | Read depth per base. | per-sample |
 | Insaflu typing results | ./{{ alias }}/typing/insaflu.typing.txt | Insaflu abricate typing results. | per-sample |
 | Variants file | ./{{ alias }}/variants/variants.annotated.filtered.vcf | Called variants in VCF format. | per-sample |

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ input_reads.fastq   ─── input_directory  ─── input_directory
 | downsample | integer | Number of reads to downsample to in each direction, leave blank for no downsampling. | The workflow for each segment will first filter reads to include only those that are ±10% of the segment length before downsampling to the specified integer (taking an even split from forward and reverse reads). This downsampled data is then used in variant calling. |  |
 | medaka_consensus_model | string | The name of a Medaka model to use. By default the workflow will select an appropriate Medaka model from the basecaller configuration provided. Entering a name here will override the automated selection and use the Medaka model named here. | The workflow will attempt to map the basecalling model used to a suitable Medaka consensus model. You can override this by providing a model with this option instead. |  |
 | rbk | boolean | Set when using data created with the RBK protocol. | This prevents shorter reads being filtered out and also turns off downsampling as this is not appropriate for the shorter reads generated with RBK. | False |
+| tresh_lvl | integer | Specify when you want each sample to obtain a specific consensus consisting only of segments whose average coverage is above this parameter. | Specify parameter for process, which creates a filtered consensus file, without any segments with low representation in this sample. | 10 |
+
 
 
 ### Miscellaneous Options

--- a/bin/filtered_consensus.py
+++ b/bin/filtered_consensus.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import argparse
+import os
+import sys
+import textwrap
+try:
+    import pandas as pd
+except ModuleNotFoundError:
+    print("Error: lib not found, please install it using 'conda install conda-forge::pandas'")
+    sys.exit()
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Filter sequences based on coverage threshold.")
+    parser.add_argument("-d", "--depth", 
+                        required=True, 
+                        help="Path to the depth.txt file")
+    parser.add_argument("-c", "--consensus", 
+                        required=True, 
+                        help="Path to the draft_consensus.fasta file")
+    parser.add_argument("-t", "--treshold", 
+                        required=True, 
+                        type=int, 
+                        help='A required trash coverage level int')
+    parser.add_argument("-o", "--output_dir", 
+                        required=False, 
+                        help="Path to the output directory where filtered_cons.fasta will be saved")
+    return parser.parse_args()
+
+
+def filter_sequences(depth_file, cons_file, treshold, output_dir):
+    # Read the depth.txt into a DataFrame
+    depth = pd.read_csv(depth_file, engine='python', sep="\\s+", names=["SEG_NAME", "POS", "COVERAGE"])
+
+    # Calculate average coverage for each unique SEG_NAME
+    result = depth.groupby("SEG_NAME")["COVERAGE"].mean().reset_index()
+    result.rename(columns={"COVERAGE": "AV_COVERAGE"}, inplace=True)
+
+    # Filter the result DataFrame based on the threshold
+    filtered_result = result[result['AV_COVERAGE'] >= treshold]
+    
+    # Create the output directory if it doesn't exist
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    # Define the output file path
+    output_file = os.path.join(output_dir, "filtered_cons.fasta")
+
+    # Open the input and output files
+    with open(cons_file, "r") as infile, open(output_file, "w") as outfile:
+        current_header = None
+        current_sequence = ""
+
+        # Iterate over each line in the input file
+        for line in infile:
+            line = line.strip()  # Remove leading/trailing whitespace
+
+            # Check if the line is a header line
+            if line.startswith(">"):
+                # Check if the current sequence belongs to one of the filtered SEG_NAME values
+                if current_header in filtered_result["SEG_NAME"].values:
+                    # Write the current header and sequence to the output file
+                    formatted_sequence = "\n".join(textwrap.wrap(current_sequence, 60))
+                    outfile.write(f">{current_header}\n{formatted_sequence}\n")
+
+                # Reset the current sequence and update the current header
+                current_sequence = ""
+                current_header = line[1:]  # Remove the ">" character
+
+            else:
+                # Accumulate the sequence
+                current_sequence += line
+
+        # Write the last sequence if it belongs to one of the filtered SEG_NAME values
+        if current_header in filtered_result["SEG_NAME"].values:
+            # print(current_header)
+            formatted_sequence = "\n".join(textwrap.wrap(current_sequence, 60))
+            outfile.write(f">{current_header}\n{formatted_sequence}\n")
+
+    # Return the path to the output file
+    return output_file
+
+
+def main():
+    #Parse command line arguments
+    args = parse_arguments()
+
+    # If output directory is not provided, use current directory
+    output_dir = args.output_dir if args.output_dir else os.getcwd()
+
+    # Filter sequences based on coverage threshold
+    output_file = filter_sequences(args.depth, args.consensus, args.treshold, output_dir)
+ 
+    # Confirmation message
+    #print(f"Filtered consensus has been saved to {output_dir}{output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/06_input_parameters.md
+++ b/docs/06_input_parameters.md
@@ -17,7 +17,8 @@
 | min_qscore | number | Minimum read quality score for fastcat. | Any reads which are below quality score of 9 are not used by default. This parameter allows you to customise that. For more information on quality scores please see this blog post: https://labs.epi2me.io/quality-scores | 9 |
 | downsample | integer | Number of reads to downsample to in each direction, leave blank for no downsampling. | The workflow for each segment will first filter reads to include only those that are ±10% of the segment length before downsampling to the specified integer (taking an even split from forward and reverse reads). This downsampled data is then used in variant calling. |  |
 | medaka_consensus_model | string | The name of a Medaka model to use. By default the workflow will select an appropriate Medaka model from the basecaller configuration provided. Entering a name here will override the automated selection and use the Medaka model named here. | The workflow will attempt to map the basecalling model used to a suitable Medaka consensus model. You can override this by providing a model with this option instead. |  |
-| rbk | boolean | Set when using data created with the RBK protocol. | This prevents shorter reads being filtered out and also turns off downsampling as this is not appropriate for the shorter reads generated with RBK. | False |
+| rbk | boolean | Set when using data created with the RBK protocol. | This prevents shorter reads being filtered out and also turns off downsampling as this is not appropriate for the shorter reads generated with RBK. | False |  |
+| tresh_lvl | integer | Specify when you want each sample to obtain a specific consensus consisting only of segments whose average coverage is above this parameter. | Specify parameter for process, which creates a filtered consensus file, without any segments with low representation in this sample. | 10 |
 
 
 ### Miscellaneous Options

--- a/docs/07_outputs.md
+++ b/docs/07_outputs.md
@@ -6,6 +6,7 @@ Output files may be aggregated including information for all samples or provided
 | Typing results | ./wf-flu-results.csv | Typing results in CSV format for onward processing. | aggregated |
 | Read alignments | ./{{ alias }}/alignments/align.bam | Read allignments per sample in BAM format. | per-sample |
 | Draft consensus FASTA | ./{{ alias }}/consensus/draft.consensus.fasta | Draft and filtered by average coverage consensus sequences. | per-sample |
+| Filtered consensus FASTA | ./{{ alias }}/consensus/filtered_cons.fasta | Filtered consensus sequence above tresh coverage lvl. | per-sample |
 | Read depth | ./{{ alias }}/coverage/depth.txt | Read depth per base. | per-sample |
 | Insaflu typing results | ./{{ alias }}/typing/insaflu.typing.txt | Insaflu abricate typing results. | per-sample |
 | Variants file | ./{{ alias }}/variants/variants.annotated.filtered.vcf | Called variants in VCF format. | per-sample |

--- a/docs/07_outputs.md
+++ b/docs/07_outputs.md
@@ -5,7 +5,7 @@ Output files may be aggregated including information for all samples or provided
 | Workflow report | ./wf-flu-report.html | Easy-to-use HTML report for all samples in the run. | aggregated |
 | Typing results | ./wf-flu-results.csv | Typing results in CSV format for onward processing. | aggregated |
 | Read alignments | ./{{ alias }}/alignments/align.bam | Read allignments per sample in BAM format. | per-sample |
-| Draft consensus FASTA | ./{{ alias }}/consensus/draft.consensus.fasta | Draft consensus sequence. | per-sample |
+| Draft consensus FASTA | ./{{ alias }}/consensus/draft.consensus.fasta | Draft and filtered by average coverage consensus sequences. | per-sample |
 | Read depth | ./{{ alias }}/coverage/depth.txt | Read depth per base. | per-sample |
 | Insaflu typing results | ./{{ alias }}/typing/insaflu.typing.txt | Insaflu abricate typing results. | per-sample |
 | Variants file | ./{{ alias }}/variants/variants.annotated.filtered.vcf | Called variants in VCF format. | per-sample |

--- a/docs/12_Usage_filtered_consensus.md
+++ b/docs/12_Usage_filtered_consensus.md
@@ -1,0 +1,11 @@
+The script `filtered_consensus.py` serves as the foundation for one of the processes in the current workflow. This script is associated with the `process filterConsensus`, the description of which can be found in `main.nf`. 
+
+This script generates an additional consensus sequence file, distinct from the `draft_consensus.fasta`. The output file `filtered_cons.fasta` does not contain sequences of segments whose representation in the sample data is below a threshold value set by the user via the `-t ` parameter. The `-t` parameter is required when executing the script outside the pipeline and optional (with default value 10) when executed as one of the pipeline processes. 
+
+The `filtered_consensus.py` script can be executed outside the pipeline according to the instructions below:
+
+usage: filtered_consensus.py [-h] -d depth.txt -c draft_consensus.fasta -t TRESHOLD [-o OUTPUT_DIR]
+
+the following arguments are required: -d/--depth {path to file}, -c/--consensus {path to file}, -t/--treshold {integer}
+
+If the parameter [-o OUTPUT_DIR] is not specified, the output file will be saved in the current working directory.

--- a/docs/12_Usage_filtered_consensus.md
+++ b/docs/12_Usage_filtered_consensus.md
@@ -2,7 +2,7 @@ The script `filtered_consensus.py` serves as the foundation for one of the proce
 
 This script generates an additional consensus sequence file, distinct from the `draft_consensus.fasta`. The output file `filtered_cons.fasta` does not contain sequences of segments whose representation in the sample data is below a threshold value set by the user via the `-t ` parameter. The `-t` parameter is required when executing the script outside the pipeline. When executed as part of nextflow command, just inside it as one of the pipeline processes (with default value 10), but you would like change  defaulte value, then please use `--tresh_lvl` parameter inside nextflow command. 
 
-`nextflow run ./risbm-wf-flu --out_dir out_res --sample_sheet ./sample_sheets.csv --disable_ping True --basecaller_cfg dna_r9.4.1_e8.1_hac_prom --fastq ./input_data -profile standard`
+`nextflow run ./risbm-wf-flu --out_dir out_res --sample_sheet ./sample_sheets.csv --tresh_lvl 150 --disable_ping True --basecaller_cfg dna_r9.4.1_e8.1_hac_prom --fastq ./input_data -profile standard`
 
 The `filtered_consensus.py` script can be executed outside the pipeline according to the instructions below:
 

--- a/docs/12_Usage_filtered_consensus.md
+++ b/docs/12_Usage_filtered_consensus.md
@@ -1,6 +1,8 @@
 The script `filtered_consensus.py` serves as the foundation for one of the processes in the current workflow. This script is associated with the `process filterConsensus`, the description of which can be found in `main.nf`. 
 
-This script generates an additional consensus sequence file, distinct from the `draft_consensus.fasta`. The output file `filtered_cons.fasta` does not contain sequences of segments whose representation in the sample data is below a threshold value set by the user via the `-t ` parameter. The `-t` parameter is required when executing the script outside the pipeline and optional (with default value 10) when executed as one of the pipeline processes. 
+This script generates an additional consensus sequence file, distinct from the `draft_consensus.fasta`. The output file `filtered_cons.fasta` does not contain sequences of segments whose representation in the sample data is below a threshold value set by the user via the `-t ` parameter. The `-t` parameter is required when executing the script outside the pipeline. When executed as part of nextflow command, just inside it as one of the pipeline processes (with default value 10), but you would like change  defaulte value, then please use `--tresh_lvl` parameter inside nextflow command. 
+
+`nextflow run ./risbm-wf-flu --out_dir out_res --sample_sheet ./sample_sheets.csv --disable_ping True --basecaller_cfg dna_r9.4.1_e8.1_hac_prom --fastq ./input_data -profile standard`
 
 The `filtered_consensus.py` script can be executed outside the pipeline according to the instructions below:
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,7 @@ params {
     basecaller_cfg = "dna_r10.4.1_e8.2_400bps_hac"
     medaka_consensus_model = null
     rbk = false
+    tresh_lvl = 10
 
     aws_image_prefix = null
     aws_queue = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -174,6 +174,14 @@
                     "description": "Set when using data created with the RBK protocol.",
                     "help_text": "This prevents shorter reads being filtered out and also turns off downsampling as this is not appropriate for the shorter reads generated with RBK.",
                     "default": false
+                },
+                "tresh_lvl": {
+                    "type": "integer",
+                    "title": "Consensus tresh level",
+                    "description": "Set when you want to get the specific consensus for each sample.",
+                    "help_text": "This parameter used for creating consensus only from fragments, which average coverage is above set treshlvl, for each sample.",
+                    "minimum": 0,
+                    "default": 10
                 }
             }
         },


### PR DESCRIPTION
Creating functionality filters draft_consensus.fasta by sequences average coverage by bin/filter_consensus.py

Files created: bin/filtered_consensus.py; docs/12_Usage_filtered_consensus.md

Files edited: main.nf; readme.md; nextflow_schema.json; nextflow.config; docs/06_input_parameters.md; docs/07_outputs.md; 